### PR TITLE
Fix sending message on delete when create_only set

### DIFF
--- a/internal/provider/eventpush_aws_sns_publish_message.go
+++ b/internal/provider/eventpush_aws_sns_publish_message.go
@@ -202,10 +202,12 @@ func (r *AWSSNSPublishMessageResource) Delete(ctx context.Context, request resou
 		return
 	}
 
-	err := publishMessage(ctx, r.AWSClient, &data, "delete")
-	if err != nil {
-		response.Diagnostics.AddError("Error sending message to SNS topic.", err.Error())
-		return
+	if !data.CreateOnly.ValueBool() {
+		err := publishMessage(ctx, r.AWSClient, &data, "delete")
+		if err != nil {
+			response.Diagnostics.AddError("Error sending message to SNS topic.", err.Error())
+			return
+		}
 	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)

--- a/internal/provider/eventpush_aws_sqs_send_message.go
+++ b/internal/provider/eventpush_aws_sqs_send_message.go
@@ -215,10 +215,12 @@ func (r *AWSSQSSendMessageResource) Delete(ctx context.Context, request resource
 		return
 	}
 
-	err := sendMessage(ctx, r.AWSClient, &data, "delete")
-	if err != nil {
-		response.Diagnostics.AddError("Error sending message to SQS queue.", err.Error())
-		return
+	if !data.CreateOnly.ValueBool() {
+		err := sendMessage(ctx, r.AWSClient, &data, "delete")
+		if err != nil {
+			response.Diagnostics.AddError("Error sending message to SQS queue.", err.Error())
+			return
+		}
 	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)


### PR DESCRIPTION
When create_only is set, the delete lifecycle should not send a message.